### PR TITLE
Add neural network explainer site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>神经网络解释站</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar">
+            <a class="logo" href="#">神经网络指南</a>
+            <button class="nav-toggle" aria-label="展开导航">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <ul class="nav-links">
+                <li><a href="#overview">概览</a></li>
+                <li><a href="#anatomy">组成</a></li>
+                <li><a href="#training">训练流程</a></li>
+                <li><a href="#architectures">网络类型</a></li>
+                <li><a href="#playground">交互体验</a></li>
+                <li><a href="#applications">应用</a></li>
+                <li><a href="#resources">术语&延伸</a></li>
+            </ul>
+        </nav>
+        <section class="hero" id="top">
+            <div class="hero-text">
+                <h1>用直观的方式理解神经网络</h1>
+                <p>神经网络是现代人工智能的核心。本网站以图文和互动的方式，带你从零认识它的概念、结构和真实应用。</p>
+                <a class="cta" href="#overview">开始探索</a>
+            </div>
+            <div class="hero-visual" aria-hidden="true">
+                <div class="node-layer">
+                    <span class="node"></span>
+                    <span class="node"></span>
+                    <span class="node"></span>
+                </div>
+                <div class="node-layer">
+                    <span class="node"></span>
+                    <span class="node"></span>
+                    <span class="node"></span>
+                    <span class="node"></span>
+                </div>
+                <div class="node-layer">
+                    <span class="node"></span>
+                    <span class="node"></span>
+                </div>
+            </div>
+        </section>
+    </header>
+
+    <main>
+        <section id="overview" class="section">
+            <div class="section-header">
+                <h2>什么是神经网络？</h2>
+                <p>神经网络模仿人脑“神经元”互联的方式，从数据中学习复杂的模式与关系，是深度学习最重要的算法之一。</p>
+            </div>
+            <div class="two-column">
+                <div class="column">
+                    <h3>核心思想</h3>
+                    <ul class="feature-list">
+                        <li><strong>分层结构：</strong>输入层、隐藏层、输出层层层推进信息。</li>
+                        <li><strong>可学习参数：</strong>连接线上的<strong>权重</strong>和每个节点的<strong>偏置</strong>决定输出结果。</li>
+                        <li><strong>非线性激活：</strong>让网络能够拟合复杂的非线性关系。</li>
+                        <li><strong>端到端学习：</strong>网络自动从数据中提取特征，减少人工设计。</li>
+                    </ul>
+                </div>
+                <div class="column">
+                    <h3>为什么它重要？</h3>
+                    <p>从智能语音助手到自动驾驶汽车，神经网络几乎参与了所有前沿的人工智能产品。得益于海量数据和算力，它们能够“自我调节”以完成图像识别、自然语言理解、生成创意内容等任务。</p>
+                    <p>理解神经网络有助于我们正确使用 AI 工具、做出负责任的技术决策，并发掘新的创新机会。</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="anatomy" class="section accent">
+            <div class="section-header">
+                <h2>神经网络的构成</h2>
+                <p>每一个“神经元”其实是一段简单的数学计算，但大量神经元互相连接后，就能形成强大的表示能力。</p>
+            </div>
+            <div class="card-grid">
+                <article class="info-card">
+                    <h3>神经元</h3>
+                    <p>接收多个输入，经过加权求和与激活函数处理后输出结果。常见激活函数有 ReLU、Sigmoid、Tanh 等。</p>
+                </article>
+                <article class="info-card">
+                    <h3>层</h3>
+                    <p>多个神经元组成一层。隐藏层负责逐步提取抽象特征，层数越多，网络越“深”。</p>
+                </article>
+                <article class="info-card">
+                    <h3>权重与偏置</h3>
+                    <p>权重衡量输入的重要性，偏置帮助模型灵活地调整输出。训练的目标就是找到最优参数。</p>
+                </article>
+                <article class="info-card">
+                    <h3>损失函数</h3>
+                    <p>衡量预测与真实答案的差距。常见损失包括均方误差、交叉熵等。</p>
+                </article>
+                <article class="info-card">
+                    <h3>优化器</h3>
+                    <p>例如 SGD、Adam，通过迭代更新参数来减少损失，驱动网络逐渐学到正确的模式。</p>
+                </article>
+                <article class="info-card">
+                    <h3>正则化</h3>
+                    <p>例如 Dropout、L2 惩罚，防止网络在训练数据上记忆过度，从而提升泛化能力。</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="training" class="section">
+            <div class="section-header">
+                <h2>训练流程一览</h2>
+                <p>训练神经网络是一套循环往复的流程，通过不断试错来提升表现。</p>
+            </div>
+            <ol class="timeline">
+                <li>
+                    <h3>1. 准备数据</h3>
+                    <p>收集、清洗、划分数据集（训练/验证/测试），并进行必要的标准化或增强。</p>
+                </li>
+                <li>
+                    <h3>2. 前向传播</h3>
+                    <p>输入数据经过各层计算得到预测输出。</p>
+                </li>
+                <li>
+                    <h3>3. 计算损失</h3>
+                    <p>比较预测与目标之间的差异，得到当前网络的误差。</p>
+                </li>
+                <li>
+                    <h3>4. 反向传播</h3>
+                    <p>利用链式法则计算损失对每个参数的梯度，确定更新方向。</p>
+                </li>
+                <li>
+                    <h3>5. 更新参数</h3>
+                    <p>优化器按照学习率调整权重和偏置，准备下一次循环。</p>
+                </li>
+                <li>
+                    <h3>6. 评估与调优</h3>
+                    <p>在验证集上监控性能，调整超参数并防止过拟合，直到达到满意结果。</p>
+                </li>
+            </ol>
+        </section>
+
+        <section id="architectures" class="section accent">
+            <div class="section-header">
+                <h2>常见网络架构</h2>
+                <p>不同的任务需要不同的网络结构，每种架构都有自己的优势。</p>
+            </div>
+            <div class="card-grid wide">
+                <article class="info-card">
+                    <h3>前馈神经网络（FNN）</h3>
+                    <p>信息只沿一个方向流动，适用于表格、结构化数据，是理解神经网络的基础。</p>
+                </article>
+                <article class="info-card">
+                    <h3>卷积神经网络（CNN）</h3>
+                    <p>利用卷积层提取局部特征，擅长处理图像、视频等带有空间结构的数据。</p>
+                </article>
+                <article class="info-card">
+                    <h3>循环神经网络（RNN）</h3>
+                    <p>通过循环结构记忆时间序列信息，在语音识别、文本分析等任务中表现突出。</p>
+                </article>
+                <article class="info-card">
+                    <h3>Transformer</h3>
+                    <p>基于自注意力机制并行处理序列，是当前自然语言处理与生成式 AI 的主流架构。</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="playground" class="section">
+            <div class="section-header">
+                <h2>交互体验：感受单个神经元</h2>
+                <p>调整权重、偏置和输入，观察一个简单的两输入神经元如何产生输出。</p>
+            </div>
+            <div class="playground">
+                <div class="controls">
+                    <div class="control-group">
+                        <label for="input1">输入 x₁</label>
+                        <input type="range" id="input1" min="-1" max="1" step="0.1" value="0.5">
+                        <span class="value" data-target="input1">0.5</span>
+                    </div>
+                    <div class="control-group">
+                        <label for="input2">输入 x₂</label>
+                        <input type="range" id="input2" min="-1" max="1" step="0.1" value="-0.2">
+                        <span class="value" data-target="input2">-0.2</span>
+                    </div>
+                    <div class="control-group">
+                        <label for="weight1">权重 w₁</label>
+                        <input type="range" id="weight1" min="-3" max="3" step="0.1" value="1.2">
+                        <span class="value" data-target="weight1">1.2</span>
+                    </div>
+                    <div class="control-group">
+                        <label for="weight2">权重 w₂</label>
+                        <input type="range" id="weight2" min="-3" max="3" step="0.1" value="-0.8">
+                        <span class="value" data-target="weight2">-0.8</span>
+                    </div>
+                    <div class="control-group">
+                        <label for="bias">偏置 b</label>
+                        <input type="range" id="bias" min="-2" max="2" step="0.1" value="0.2">
+                        <span class="value" data-target="bias">0.2</span>
+                    </div>
+                    <div class="control-group">
+                        <label for="activation">激活函数</label>
+                        <select id="activation">
+                            <option value="relu">ReLU</option>
+                            <option value="sigmoid">Sigmoid</option>
+                            <option value="tanh">Tanh</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="results">
+                    <h3>计算过程</h3>
+                    <p>加权求和：<span id="weighted-sum">0</span></p>
+                    <p>激活后输出：<span id="activated-output">0</span></p>
+                    <div class="chart" aria-hidden="true">
+                        <div class="bar" id="output-bar"></div>
+                    </div>
+                    <p class="hint">输出值范围在 0 到 1（Sigmoid）、-1 到 1（Tanh）或 ≥0（ReLU）。观察不同激活函数对结果的影响。</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="applications" class="section accent">
+            <div class="section-header">
+                <h2>现实世界中的应用</h2>
+                <p>神经网络正在各个行业改变我们的生活与工作方式。</p>
+            </div>
+            <div class="application-grid">
+                <article>
+                    <h3>计算机视觉</h3>
+                    <p>自动驾驶、医学影像诊断、安防监控中使用 CNN 识别场景与目标。</p>
+                </article>
+                <article>
+                    <h3>自然语言处理</h3>
+                    <p>翻译、聊天机器人、文本摘要依赖 RNN 与 Transformer 对语言建模。</p>
+                </article>
+                <article>
+                    <h3>推荐系统</h3>
+                    <p>电商与流媒体平台利用神经网络分析用户行为，提供个性化推荐。</p>
+                </article>
+                <article>
+                    <h3>生成式 AI</h3>
+                    <p>扩散模型、生成对抗网络（GAN）可以生成图片、音乐，甚至代码。</p>
+                </article>
+                <article>
+                    <h3>工业与科学</h3>
+                    <p>用于预测设备故障、优化能源调度、加速材料和药物发现。</p>
+                </article>
+                <article>
+                    <h3>负责任的 AI</h3>
+                    <p>解释性、偏见检测和模型监控帮助我们建立值得信赖的 AI 系统。</p>
+                </article>
+            </div>
+        </section>
+
+        <section id="resources" class="section">
+            <div class="section-header">
+                <h2>术语速查与延伸阅读</h2>
+                <p>继续深入学习神经网络，可以从以下关键词和资源开始。</p>
+            </div>
+            <div class="resources">
+                <dl class="glossary">
+                    <div>
+                        <dt>梯度</dt>
+                        <dd>指损失函数对参数的导数，告诉我们参数需要往哪个方向调整。</dd>
+                    </div>
+                    <div>
+                        <dt>学习率</dt>
+                        <dd>控制每次更新的幅度，过大可能发散，过小训练会很慢。</dd>
+                    </div>
+                    <div>
+                        <dt>批量（Batch）</dt>
+                        <dd>一次前向/反向传播处理的数据数量，影响效率与稳定性。</dd>
+                    </div>
+                    <div>
+                        <dt>过拟合</dt>
+                        <dd>模型在训练集表现很好，但对新数据泛化能力差。</dd>
+                    </div>
+                    <div>
+                        <dt>迁移学习</dt>
+                        <dd>利用在大数据集上训练好的模型，快速适配新的任务。</dd>
+                    </div>
+                </dl>
+                <div class="links">
+                    <h3>推荐阅读</h3>
+                    <ul>
+                        <li><a href="https://www.deeplearningbook.org/" target="_blank" rel="noopener">Deep Learning 电子书</a></li>
+                        <li><a href="https://playground.tensorflow.org/" target="_blank" rel="noopener">TensorFlow Playground</a></li>
+                        <li><a href="https://distill.pub/" target="_blank" rel="noopener">Distill 可视化文章</a></li>
+                        <li><a href="https://www.fast.ai/" target="_blank" rel="noopener">fast.ai 实践课程</a></li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>希望这个网站能帮助你迈出理解神经网络的第一步。保持好奇，继续探索 AI 的世界！</p>
+        <a class="back-to-top" href="#top">回到顶部</a>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,108 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const body = document.body;
+    const toggle = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelectorAll('.nav-links a');
+
+    if (toggle) {
+        toggle.addEventListener('click', () => {
+            body.classList.toggle('nav-open');
+        });
+    }
+
+    navLinks.forEach((link) => {
+        link.addEventListener('click', () => {
+            body.classList.remove('nav-open');
+        });
+    });
+
+    const ranges = document.querySelectorAll('.playground input[type="range"]');
+    const valueDisplays = document.querySelectorAll('.playground .value');
+    const activationSelect = document.getElementById('activation');
+    const weightedSumEl = document.getElementById('weighted-sum');
+    const activatedOutputEl = document.getElementById('activated-output');
+    const outputBar = document.getElementById('output-bar');
+
+    function formatNumber(value) {
+        return Number.parseFloat(value).toFixed(3);
+    }
+
+    function sigmoid(x) {
+        return 1 / (1 + Math.exp(-x));
+    }
+
+    function relu(x) {
+        return Math.max(0, x);
+    }
+
+    function tanh(x) {
+        return Math.tanh ? Math.tanh(x) : (Math.exp(x) - Math.exp(-x)) / (Math.exp(x) + Math.exp(-x));
+    }
+
+    function normalizeOutput(activation, value) {
+        switch (activation) {
+            case 'sigmoid':
+                return value; // already between 0 and 1
+            case 'tanh':
+                return (value + 1) / 2; // map -1..1 -> 0..1
+            case 'relu':
+            default:
+                return Math.min(relu(value) / 3, 1); // assume interesting range within 0..3
+        }
+    }
+
+    function updateBarColor(activation, value) {
+        if (activation === 'tanh' && value < 0) {
+            return 'linear-gradient(180deg, rgba(244, 114, 182, 0.8), rgba(192, 132, 252, 0.35))';
+        }
+        return 'linear-gradient(180deg, rgba(56, 189, 248, 0.7), rgba(56, 189, 248, 0.25))';
+    }
+
+    function updateValues() {
+        const values = {};
+        ranges.forEach((range) => {
+            values[range.id] = Number.parseFloat(range.value);
+            const display = Array.from(valueDisplays).find((span) => span.dataset.target === range.id);
+            if (display) {
+                display.textContent = formatNumber(range.value);
+            }
+        });
+
+        const weightedSum = values.weight1 * values.input1 + values.weight2 * values.input2 + values.bias;
+        let activated;
+        const activation = activationSelect ? activationSelect.value : 'relu';
+
+        switch (activation) {
+            case 'sigmoid':
+                activated = sigmoid(weightedSum);
+                break;
+            case 'tanh':
+                activated = tanh(weightedSum);
+                break;
+            case 'relu':
+            default:
+                activated = relu(weightedSum);
+        }
+
+        if (weightedSumEl) {
+            weightedSumEl.textContent = formatNumber(weightedSum);
+        }
+        if (activatedOutputEl) {
+            activatedOutputEl.textContent = formatNumber(activated);
+        }
+        if (outputBar) {
+            const normalized = normalizeOutput(activation, activated);
+            outputBar.style.height = `${Math.max(0, Math.min(normalized, 1)) * 100}%`;
+            outputBar.style.background = updateBarColor(activation, activated);
+        }
+    }
+
+    if (ranges.length) {
+        ranges.forEach((range) => {
+            range.addEventListener('input', updateValues);
+        });
+        if (activationSelect) {
+            activationSelect.addEventListener('change', updateValues);
+        }
+        updateValues();
+    }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,558 @@
+:root {
+    --bg-color: #0f172a;
+    --surface-color: #111c33;
+    --accent-color: #38bdf8;
+    --accent-strong: #0ea5e9;
+    --text-color: #e2e8f0;
+    --muted-color: #94a3b8;
+    --card-bg: rgba(15, 23, 42, 0.7);
+    --accent-bg: rgba(56, 189, 248, 0.08);
+    --border-color: rgba(148, 163, 184, 0.2);
+    --shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+    --font-sans: "Noto Sans SC", "Segoe UI", "PingFang SC", "Helvetica Neue", Arial, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-sans);
+    background: linear-gradient(145deg, #020617, #0f172a 45%, #172554 100%);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+img,
+svg {
+    max-width: 100%;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.site-header {
+    background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.25), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(96, 165, 250, 0.2), transparent 60%),
+        linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.95));
+    padding-bottom: 4rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.navbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem clamp(1.5rem, 5vw, 4rem);
+    position: relative;
+    z-index: 2;
+}
+
+.logo {
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--text-color);
+    text-transform: uppercase;
+}
+
+.nav-links {
+    display: flex;
+    gap: 1.5rem;
+    list-style: none;
+}
+
+.nav-links a {
+    font-size: 0.95rem;
+    color: var(--muted-color);
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+    color: var(--accent-color);
+    transform: translateY(-2px);
+}
+
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    gap: 0.35rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+}
+
+.nav-toggle span {
+    width: 1.75rem;
+    height: 2px;
+    background: var(--text-color);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+body.nav-open .nav-toggle span:nth-child(1) {
+    transform: translateY(6px) rotate(45deg);
+}
+
+body.nav-open .nav-toggle span:nth-child(2) {
+    opacity: 0;
+}
+
+body.nav-open .nav-toggle span:nth-child(3) {
+    transform: translateY(-6px) rotate(-45deg);
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 3rem;
+    padding: 3rem clamp(1.5rem, 5vw, 4rem) 0;
+    align-items: center;
+    position: relative;
+    z-index: 1;
+}
+
+.hero-text h1 {
+    font-size: clamp(2.4rem, 4vw + 1rem, 3.5rem);
+    margin-bottom: 1rem;
+    line-height: 1.2;
+}
+
+.hero-text p {
+    margin-bottom: 2rem;
+    color: var(--muted-color);
+    max-width: 32rem;
+}
+
+.cta {
+    display: inline-block;
+    padding: 0.8rem 1.6rem;
+    background: linear-gradient(120deg, var(--accent-strong), #60a5fa);
+    color: #0b1120;
+    font-weight: 700;
+    border-radius: 999px;
+    box-shadow: 0 12px 30px rgba(14, 165, 233, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta:hover,
+.cta:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 40px rgba(14, 165, 233, 0.45);
+}
+
+.hero-visual {
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+}
+
+.node-layer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem 1.2rem;
+    background: rgba(148, 163, 184, 0.05);
+    border-radius: 2rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.node {
+    width: 1.6rem;
+    height: 1.6rem;
+    background: rgba(56, 189, 248, 0.25);
+    border: 2px solid rgba(56, 189, 248, 0.6);
+    border-radius: 50%;
+    box-shadow: 0 0 20px rgba(56, 189, 248, 0.4);
+    animation: pulse 3s ease-in-out infinite;
+}
+
+.node:nth-child(2) {
+    animation-delay: 0.5s;
+}
+
+.node:nth-child(3) {
+    animation-delay: 1s;
+}
+
+@keyframes pulse {
+    0%,
+    100% {
+        transform: scale(1);
+        opacity: 0.75;
+    }
+    50% {
+        transform: scale(1.15);
+        opacity: 1;
+    }
+}
+
+main {
+    margin-top: -2rem;
+    position: relative;
+    z-index: 2;
+}
+
+.section {
+    padding: clamp(3rem, 8vw, 5rem) clamp(1.5rem, 6vw, 5rem);
+    background: rgba(10, 17, 31, 0.8);
+    backdrop-filter: blur(6px);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.section.accent {
+    background: rgba(15, 23, 42, 0.8);
+}
+
+.section-header {
+    max-width: 48rem;
+    margin: 0 auto 2.5rem;
+    text-align: center;
+}
+
+.section-header h2 {
+    font-size: clamp(2rem, 3vw + 1rem, 2.6rem);
+    margin-bottom: 0.75rem;
+}
+
+.section-header p {
+    color: var(--muted-color);
+}
+
+.two-column {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 2.5rem;
+    align-items: start;
+}
+
+.column h3 {
+    margin-top: 0;
+    font-size: 1.4rem;
+}
+
+.feature-list {
+    margin: 0;
+    padding-left: 1rem;
+    color: var(--muted-color);
+}
+
+.feature-list li {
+    margin-bottom: 0.75rem;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.8rem;
+}
+
+.card-grid.wide {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.info-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 1.2rem;
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.info-card:hover,
+.info-card:focus-within {
+    transform: translateY(-6px);
+    border-color: rgba(56, 189, 248, 0.6);
+}
+
+.timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+}
+
+.timeline::before {
+    content: "";
+    position: absolute;
+    left: 1rem;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    width: 2px;
+    background: linear-gradient(180deg, rgba(56, 189, 248, 0.6), rgba(96, 165, 250, 0.2));
+}
+
+.timeline li {
+    margin-left: 3rem;
+    margin-bottom: 2rem;
+    padding-left: 1.5rem;
+    border-left: 2px solid transparent;
+    position: relative;
+}
+
+.timeline li::before {
+    content: "";
+    position: absolute;
+    left: -2.55rem;
+    top: 0.2rem;
+    width: 0.9rem;
+    height: 0.9rem;
+    border-radius: 50%;
+    border: 2px solid var(--accent-color);
+    background: var(--bg-color);
+    box-shadow: 0 0 20px rgba(56, 189, 248, 0.6);
+}
+
+.timeline li h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1.2rem;
+}
+
+.timeline li p {
+    margin: 0;
+    color: var(--muted-color);
+}
+
+.playground {
+    display: grid;
+    grid-template-columns: minmax(240px, 360px) minmax(260px, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+    background: rgba(15, 23, 42, 0.75);
+    border-radius: 1.5rem;
+    padding: 2rem;
+    border: 1px solid var(--border-color);
+    box-shadow: var(--shadow);
+}
+
+.controls {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.control-group {
+    display: grid;
+    gap: 0.4rem;
+}
+
+.control-group label {
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.control-group input[type="range"] {
+    width: 100%;
+}
+
+.control-group select {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    padding: 0.6rem 0.75rem;
+    color: var(--text-color);
+}
+
+.value {
+    font-size: 0.9rem;
+    color: var(--muted-color);
+}
+
+.results h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.results p {
+    margin: 0.5rem 0;
+    color: var(--muted-color);
+}
+
+.chart {
+    margin: 1.5rem 0;
+    width: 100%;
+    height: 200px;
+    background: rgba(148, 163, 184, 0.08);
+    border-radius: 1rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.bar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: linear-gradient(180deg, rgba(56, 189, 248, 0.7), rgba(56, 189, 248, 0.25));
+    transition: height 0.3s ease, filter 0.3s ease;
+    filter: drop-shadow(0 10px 18px rgba(14, 165, 233, 0.4));
+}
+
+.hint {
+    font-size: 0.85rem;
+    color: var(--muted-color);
+}
+
+.application-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.8rem;
+}
+
+.application-grid article {
+    background: rgba(56, 189, 248, 0.08);
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    border-radius: 1.25rem;
+    padding: 1.6rem;
+    transition: transform 0.2s ease;
+}
+
+.application-grid article:hover {
+    transform: translateY(-4px);
+}
+
+.resources {
+    display: grid;
+    grid-template-columns: minmax(260px, 2fr) minmax(220px, 1fr);
+    gap: 2rem;
+}
+
+.glossary {
+    margin: 0;
+}
+
+.glossary div {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid var(--border-color);
+    border-radius: 1rem;
+    padding: 1.2rem 1.4rem;
+    margin-bottom: 1rem;
+}
+
+.glossary dt {
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+}
+
+.glossary dd {
+    margin: 0;
+    color: var(--muted-color);
+}
+
+.links ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.links a {
+    color: var(--accent-color);
+    font-weight: 600;
+}
+
+.links a::after {
+    content: " ↗";
+    font-size: 0.85rem;
+    color: rgba(56, 189, 248, 0.75);
+}
+
+.site-footer {
+    text-align: center;
+    padding: 2.5rem 1rem 3rem;
+    color: var(--muted-color);
+}
+
+.back-to-top {
+    display: inline-block;
+    margin-top: 1.2rem;
+    padding: 0.6rem 1.4rem;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 999px;
+    color: var(--text-color);
+    transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.back-to-top:hover,
+.back-to-top:focus {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+@media (max-width: 960px) {
+    .navbar {
+        padding: 1.25rem clamp(1rem, 5vw, 2rem);
+    }
+
+    .playground {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .nav-links {
+        position: absolute;
+        right: clamp(1rem, 4vw, 2rem);
+        top: 4.4rem;
+        flex-direction: column;
+        align-items: flex-start;
+        background: rgba(15, 23, 42, 0.95);
+        padding: 1.5rem;
+        border-radius: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 20px 30px rgba(2, 6, 23, 0.5);
+        display: none;
+    }
+
+    body.nav-open .nav-links {
+        display: flex;
+    }
+
+    .nav-toggle {
+        display: inline-flex;
+    }
+
+    .timeline::before {
+        left: 0.2rem;
+    }
+
+    .timeline li {
+        margin-left: 1.8rem;
+        padding-left: 1.2rem;
+    }
+
+    .timeline li::before {
+        left: -1.85rem;
+    }
+
+    .resources {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 540px) {
+    .hero {
+        text-align: center;
+    }
+
+    .hero-text p {
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .hero-visual {
+        justify-content: center;
+    }
+
+    .two-column {
+        gap: 2rem;
+    }
+}


### PR DESCRIPTION
## Summary
- create a single-page Chinese website that introduces neural networks with overview, architecture, training flow, applications, and resources
- add polished styling with gradients, cards, responsive layouts, and animated hero nodes to present the content attractively
- implement a mobile navigation toggle and an interactive neuron playground to visualize how weights, bias, and activation change outputs

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68c8d70bf74483289bd7516cd039e988